### PR TITLE
Fix: 자잘한 버그 수정

### DIFF
--- a/samsungT/Models/DatabaseHelper.cs
+++ b/samsungT/Models/DatabaseHelper.cs
@@ -248,7 +248,7 @@ namespace samsungT.Models
             {
                 using (SqlConnection connection = new SqlConnection(connectionString))
                 {
-                    string q = "SELECT GameID, Date, HomeTeamID, AwayTeamID, HomeScore, AwayScore FROM Games";
+                    string q = "SELECT GameID, Date, HomeTeamID, AwayTeamID, HomeScore, AwayScore FROM Games ORDER BY Date DESC";
                     SqlCommand cmd = new SqlCommand(q, connection);
 
                     connection.Open();

--- a/samsungT/Views/mainForm.Designer.cs
+++ b/samsungT/Views/mainForm.Designer.cs
@@ -28,9 +28,9 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea2 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
-            System.Windows.Forms.DataVisualization.Charting.Legend legend2 = new System.Windows.Forms.DataVisualization.Charting.Legend();
-            System.Windows.Forms.DataVisualization.Charting.Series series2 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea1 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Legend legend1 = new System.Windows.Forms.DataVisualization.Charting.Legend();
+            System.Windows.Forms.DataVisualization.Charting.Series series1 = new System.Windows.Forms.DataVisualization.Charting.Series();
             this.resisterGame = new System.Windows.Forms.Button();
             this.resisterTeam = new System.Windows.Forms.Button();
             this.resisterPlayer = new System.Windows.Forms.Button();
@@ -84,6 +84,7 @@
             this.clickHomeScore = new System.Windows.Forms.Label();
             this.thundersCalender = new calenderBasketball.ThundersCalender();
             this.thundersCalender2 = new calenderBasketball.ThundersCalender();
+            this.Button_BackClick = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.winRateChart)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -211,19 +212,19 @@
             // winRateChart
             // 
             this.winRateChart.BackImageWrapMode = System.Windows.Forms.DataVisualization.Charting.ChartImageWrapMode.Scaled;
-            chartArea2.Name = "ChartArea1";
-            this.winRateChart.ChartAreas.Add(chartArea2);
-            legend2.Name = "Legend1";
-            this.winRateChart.Legends.Add(legend2);
+            chartArea1.Name = "ChartArea1";
+            this.winRateChart.ChartAreas.Add(chartArea1);
+            legend1.Name = "Legend1";
+            this.winRateChart.Legends.Add(legend1);
             this.winRateChart.Location = new System.Drawing.Point(1000, 18);
             this.winRateChart.Name = "winRateChart";
             this.winRateChart.Palette = System.Windows.Forms.DataVisualization.Charting.ChartColorPalette.Excel;
-            series2.ChartArea = "ChartArea1";
-            series2.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Doughnut;
-            series2.CustomProperties = "PieStartAngle=270";
-            series2.Legend = "Legend1";
-            series2.Name = "Series1";
-            this.winRateChart.Series.Add(series2);
+            series1.ChartArea = "ChartArea1";
+            series1.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Doughnut;
+            series1.CustomProperties = "PieStartAngle=270";
+            series1.Legend = "Legend1";
+            series1.Name = "Series1";
+            this.winRateChart.Series.Add(series1);
             this.winRateChart.Size = new System.Drawing.Size(317, 248);
             this.winRateChart.TabIndex = 7;
             this.winRateChart.Text = "chart1";
@@ -669,13 +670,24 @@
             this.thundersCalender2.Size = new System.Drawing.Size(8, 43);
             this.thundersCalender2.TabIndex = 22;
             // 
+            // Button_BackClick
+            // 
+            this.Button_BackClick.Font = new System.Drawing.Font("Pretendard Variable", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.Button_BackClick.Location = new System.Drawing.Point(552, 253);
+            this.Button_BackClick.Name = "Button_BackClick";
+            this.Button_BackClick.Size = new System.Drawing.Size(68, 23);
+            this.Button_BackClick.TabIndex = 24;
+            this.Button_BackClick.Text = "돌아가기";
+            this.Button_BackClick.UseVisualStyleBackColor = true;
+            this.Button_BackClick.Click += new System.EventHandler(this.Button_BackClick_Click);
+            // 
             // mainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1329, 566);
+            this.Controls.Add(this.Button_BackClick);
             this.Controls.Add(this.thundersCalender);
-            this.Controls.Add(this.thundersCalender2);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.winRateText);
             this.Controls.Add(this.button3);
@@ -763,6 +775,7 @@
         private System.Windows.Forms.Label clickScore;
         private calenderBasketball.ThundersCalender thundersCalender2;
         private calenderBasketball.ThundersCalender thundersCalender;
+        private System.Windows.Forms.Button Button_BackClick;
     }
 }
 

--- a/samsungT/Views/mainForm.cs
+++ b/samsungT/Views/mainForm.cs
@@ -187,6 +187,7 @@ namespace samsungT
             List<Team> teams = db.GetTeams();
 
             Team TeamID = null;
+            double winRate;
 
             foreach (Team team in teams)
             {
@@ -200,10 +201,22 @@ namespace samsungT
             if (TeamID != null)
             {
                 int totalGames = TeamID.Wins + TeamID.Losses;
-                double winRate = totalGames > 0 ? (double)TeamID.Wins / totalGames * 100 : 0;
+                if(teamID == 1)
+                {
+                    winRate = totalGames > 0 ? (double)TeamID.Wins / totalGames * 100 : 0;
+                    winRateChart.Series[0].Points.AddXY("승리", TeamID.Wins);
+                    winRateChart.Series[0].Points.AddXY("패배", TeamID.Losses);
+                }
+                else // 데이터베이스에 기록되는 정보는 전부 삼성썬더스 기준이므로, 차트에 그려질 때 반대로 그려져야 함
+                {
+                    winRate = totalGames > 0 ? (double)100 - (((double)TeamID.Wins / totalGames * 100)) : 0;
+                    winRateChart.Series[0].Points.AddXY("승리", TeamID.Losses);
+                    winRateChart.Series[0].Points.AddXY("패배", TeamID.Wins);
+                }
+                winRateChart.Series[0].Points[0].Color = Color.LightBlue;
+                winRateChart.Series[0].Points[1].Color = Color.LightCoral;
 
-                winRateChart.Series[0].Points.AddXY("승리",TeamID.Wins);
-                winRateChart.Series[0].Points.AddXY("패배",TeamID.Losses);
+
 
                 string WinRateText = $"{winRate:F2}%";
                 winRateText.Text = WinRateText; 
@@ -465,7 +478,7 @@ namespace samsungT
             }
         }
 
-        private void oneMoreClickButton(Button clickButton, int chartType)
+        private void oneMoreClickButton(Button clickButton, int KBLNum)
         {
             if (lastButton == clickButton)
             {
@@ -482,7 +495,7 @@ namespace samsungT
 
                 setButtonColor(clickButton);
                 lastButton = clickButton;
-                loadWinRateChart(chartType);
+                loadWinRateChart(KBLNum);
             }
         }
 

--- a/samsungT/Views/mainForm.cs
+++ b/samsungT/Views/mainForm.cs
@@ -298,8 +298,14 @@ namespace samsungT
                 totalRebound += player.Rebound;
                 totalAssist += player.Assist;
             }
-
+            clickChangeTitle.Text = "STATUS";
+            clickHomeScore.Text = "";
+            label3.Text = "";
+            clickAwayScore.Text = "";
+            clickCity.Text = "";
+            clickScoreText.Text = "총 득점";
             clickScore.Text = totalScore.ToString();
+            clickChangeText.Text = "평균 3점슛(%)\r\n평균 야투율(%)\r\n평균 자유투(%)\r\n총 리바운드\r\n총 어시스트";
             click3.Text = total3PointA > 0 ? ((float)total3Point / total3PointA * 100).ToString("F2") + "%" : 0.ToString();
             clickField.Text = totalFieldA > 0 ? ((float)totalField / totalFieldA * 100).ToString("F2") + "%" : 0.ToString();
             clickFree.Text = totalFreeA > 0 ? ((float)totalFree / totalFreeA * 100).ToString("F2") + "%" : 0.ToString();
@@ -353,6 +359,9 @@ namespace samsungT
             label3.Text = ":";
             clickAwayScore.Text = searchGame.AwayScore.ToString();
             clickCity.Text = $"{homeCityName}  :  {awayCityName}";
+            clickScore.Text = "";
+            clickScoreText.Text = "";
+            clickChangeText.Text = "3점\r\n야투\r\n자유투\r\n리바운드\r\n어시스트\r\n";
             click3.Text = $"{total3Point}/{total3PointA}";
             clickField.Text = $"{totalField}/{totalFieldA}";
             clickFree.Text = $"{totalFree}/{totalFreeA}";
@@ -376,16 +385,10 @@ namespace samsungT
             DateTime targetDate = new DateTime(year, month, day);
             Game searchGame = db.GetSearchGame(targetDate);
 
-            if (searchGame == null)
-            {
-                //버튼 enabled 작업할 것
-            }
-            else
+            if(searchGame != null)
             {
                 changeStatus(searchGame);
                 changePlayers(searchGame);
-                clickScoreText.Text = "득점";
-                clickChangeText.Text = "3점\r\n야투\r\n자유투\r\n리바운드\r\n어시스트\r\n";
             }
         
         }
@@ -529,5 +532,10 @@ namespace samsungT
             oneMoreClickButton(MOBISButton, 10);
         }
 
+        private void Button_BackClick_Click(object sender, EventArgs e)
+        {
+            loadPlayers();
+            loadStatus();
+        }
     }
 }


### PR DESCRIPTION
- 경기 선수 스택 등록에서 경기 순서를 DateTime 내림차순으로 정렬
- 돌아가기 버튼을 달아서 달력 버튼 클릭 후 원래의 스테이터스와 총 경기기록을 볼 수 있게 세팅
- 스테이터스에서 개별 경기 기록으로 갈 때 총 득점 텍스트와 점수가 남아있던 현상 수정
- 승률차트에서 썬더스를 기준으로 해야하므로 계산식을 변경함
- 승률차트 색을 변경하였음.